### PR TITLE
Handle zero-length input

### DIFF
--- a/src/hungarian.cpp
+++ b/src/hungarian.cpp
@@ -30,6 +30,7 @@ List HungarianSolver(NumericMatrix costMatrix) {
   if (nr == 0 || nc == 0) {
     List out(2);
     out[0] = 0;
+    out[1] = NumericMatrix::create(0, 2);
     out.names() = CharacterVector::create("cost", "pairs");
     return out;
   }

--- a/src/hungarian.cpp
+++ b/src/hungarian.cpp
@@ -27,6 +27,13 @@ List HungarianSolver(NumericMatrix costMatrix) {
   int nr = costMatrix.nrow();
   int nc = costMatrix.ncol();
   
+  if (nr == 0 || nc == 0) {
+    List out(2);
+    out[0] = 0;
+    out.names() = CharacterVector::create("cost", "pairs");
+    return out;
+  }
+  
   vector<double> c(nc);
   vector<vector<double>> cm(nr, c);
   for (int i=0; i < nr; i++){


### PR DESCRIPTION
Thanks for this handy package. 

It would be useful to add a sense check to avoid crashing R when a zero-length input is provided.

```r
RcppHungarian::HungarianSolver(matrix(0, 0, 0)) # Crashes R
```

One alternative would be to return an error, but I've proposed returning a zero-length, zero-score matching.

I've not checked or tested the code proposed below, but hopefully it provides a useful starting point.